### PR TITLE
Enhance Filtered trait and SQL generation for dynamic filters

### DIFF
--- a/src/filter/filters.rs
+++ b/src/filter/filters.rs
@@ -302,6 +302,39 @@ where
     }
 }
 
+/// Combines two filters with a logical OR, producing a filter that matches if either condition is true.
+///
+/// This function is useful for constructing complex query conditions where you want to match
+/// records that satisfy at least one of the provided filters.
+///
+/// # Arguments
+///
+/// * `filter1` - The first filter condition.
+/// * `filter2` - The second filter condition.
+///
+/// # Returns
+///
+/// An [`OrFilter`] representing the logical OR of the two filters.
+///
+/// # Example
+///
+/// ```
+/// use lume::filter::{or, eq_value, lte};
+/// use lume::define_schema;
+///
+/// define_schema! {
+///     User {
+///         id: i32 [primary_key()],
+///         name: String [not_null()],
+///         age: i32,
+///     }
+/// }
+///
+/// let filter = or(
+///     eq_value(User::name(), "Alice"),
+///     lte(User::age(), 18)
+/// );
+/// ```
 pub fn or(filter1: impl Filtered + 'static, filter2: impl Filtered + 'static) -> OrFilter {
     OrFilter {
         filter1: Box::new(filter1),
@@ -309,6 +342,39 @@ pub fn or(filter1: impl Filtered + 'static, filter2: impl Filtered + 'static) ->
     }
 }
 
+/// Combines two filters with a logical AND, producing a filter that matches if both conditions are true.
+///
+/// This function is useful for constructing complex query conditions where you want to match
+/// records that satisfy both of the provided filters.
+///
+/// # Arguments
+///
+/// * `filter1` - The first filter condition.
+/// * `filter2` - The second filter condition.
+///
+/// # Returns
+///
+/// An [`AndFilter`] representing the logical AND of the two filters.
+///
+/// # Example
+///
+/// ```
+/// use lume::filter::{and, eq_value, lte};
+/// use lume::define_schema;
+///
+/// define_schema! {
+///     User {
+///         id: i32 [primary_key()],
+///         name: String [not_null()],
+///         age: i32,
+///     }
+/// }
+///
+/// let filter = and(
+///     eq_value(User::name(), "Alice"),
+///     lte(User::age(), 18)
+/// );
+/// ```
 pub fn and(filter1: impl Filtered + 'static, filter2: impl Filtered + 'static) -> AndFilter {
     AndFilter {
         filter1: Box::new(filter1),

--- a/src/filter/filters.rs
+++ b/src/filter/filters.rs
@@ -321,6 +321,8 @@ where
 /// ```
 /// use lume::filter::{or, eq_value, lte};
 /// use lume::define_schema;
+/// use lume::schema::Schema;
+/// use lume::schema::ColumnInfo;
 ///
 /// define_schema! {
 ///     User {
@@ -361,6 +363,8 @@ pub fn or(filter1: impl Filtered + 'static, filter2: impl Filtered + 'static) ->
 /// ```
 /// use lume::filter::{and, eq_value, lte};
 /// use lume::define_schema;
+/// use lume::schema::Schema;
+/// use lume::schema::ColumnInfo;
 ///
 /// define_schema! {
 ///     User {

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -119,24 +119,23 @@ pub struct Filter {
 /// # Example
 ///
 /// ```rust
-/// use lume::filter::OrFilter;
-/// use lume::filter::Filter;
-/// use lume::schema::Value;
+/// use lume::filter::{or, eq_value, lte};
+/// use lume::define_schema;
+/// use lume::schema::Schema;
+/// use lume::schema::ColumnInfo;
 ///
-/// let filter = OrFilter {
-///     filter1: Box::new(Filter {
-///         column_one: ("users".to_string(), "age".to_string()),
-///         filter_type: FilterType::Gt,
-///         value: Some(Value::Int8(18)),
-///         column_two: None,
-///     }),
-///     filter2: Box::new(Filter {
-///         column_one: ("users".to_string(), "age".to_string()),
-///         filter_type: FilterType::Lt,
-///         value: Some(Value::Int8(30)),
-///         column_two: None,
-///     }),
-/// };
+/// define_schema! {
+///     User {
+///         id: i32 [primary_key()],
+///         name: String [not_null()],
+///         age: i32,
+///     }
+/// }
+///
+/// let filter = or(
+///     eq_value(User::name(), "Alice"),
+///     lte(User::age(), 30)
+/// );
 /// ```
 #[derive(Debug)]
 pub struct OrFilter {
@@ -157,24 +156,23 @@ pub struct OrFilter {
 /// # Example
 ///
 /// ```rust
-/// use lume::filter::AndFilter;
-/// use lume::filter::Filter;
-/// use lume::schema::Value;
+/// use lume::filter::{and, eq_value, lt};
+/// use lume::define_schema;
+/// use lume::schema::Schema;
+/// use lume::schema::ColumnInfo;
 ///
-/// let filter = AndFilter {
-///     filter1: Box::new(Filter {
-///         column_one: ("users".to_string(), "age".to_string()),
-///         filter_type: FilterType::Gt,
-///         value: Some(Value::Int8(18)),
-///         column_two: None,
-///     }),
-///     filter2: Box::new(Filter {
-///         column_one: ("users".to_string(), "age".to_string()),
-///         filter_type: FilterType::Lt,
-///         value: Some(Value::Int8(30)),
-///         column_two: None,
-///     }),
-/// };
+/// define_schema! {
+///     User {
+///         id: i32 [primary_key()],
+///         name: String [not_null()],
+///         age: i32,
+///     }
+/// }
+///
+/// let filter = and(
+///     eq_value(User::name(), "Alice"),
+///     lt(User::age(), 30)
+/// );
 /// ```
 #[derive(Debug)]
 pub struct AndFilter {

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -140,6 +140,8 @@ pub trait Filtered: Debug {
 
     fn filter1(&self) -> Option<&dyn Filtered>;
     fn filter2(&self) -> Option<&dyn Filtered>;
+
+    fn has_more_filters(&self) -> bool;
 }
 
 impl Filtered for Filter {
@@ -172,6 +174,10 @@ impl Filtered for Filter {
     }
 
     fn is_and_filter(&self) -> bool {
+        false
+    }
+
+    fn has_more_filters(&self) -> bool {
         false
     }
 }
@@ -213,6 +219,10 @@ impl Filtered for OrFilter {
     fn is_and_filter(&self) -> bool {
         false
     }
+
+    fn has_more_filters(&self) -> bool {
+        true
+    }
 }
 
 impl Filtered for AndFilter {
@@ -251,6 +261,10 @@ impl Filtered for AndFilter {
 
     fn filter_type(&self) -> FilterType {
         FilterType::And
+    }
+
+    fn has_more_filters(&self) -> bool {
+        true
     }
 }
 

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -42,9 +42,9 @@ pub enum FilterType {
     Gte,
     /// Less than or equal operator (<=)
     Lte,
-
+    /// OR operator (logical OR)
     Or,
-
+    /// AND operator (logical AND)
     And,
 }
 
@@ -106,42 +106,130 @@ pub struct Filter {
     pub filter_type: FilterType,
 }
 
+/// Represents 'OR'  filter condition for query WHERE clauses.
+///
+/// This struct combines two filter conditions to create
+/// a condition that can be used in database queries.
+///
+/// # Fields
+///
+/// - `filter1`: The first filter condition
+/// - `filter2`: The second filter condition
+///
+/// # Example
+///
+/// ```rust
+/// use lume::filter::OrFilter;
+/// use lume::filter::Filter;
+/// use lume::schema::Value;
+///
+/// let filter = OrFilter {
+///     filter1: Box::new(Filter {
+///         column_one: ("users".to_string(), "age".to_string()),
+///         filter_type: FilterType::Gt,
+///         value: Some(Value::Int8(18)),
+///         column_two: None,
+///     }),
+///     filter2: Box::new(Filter {
+///         column_one: ("users".to_string(), "age".to_string()),
+///         filter_type: FilterType::Lt,
+///         value: Some(Value::Int8(30)),
+///         column_two: None,
+///     }),
+/// };
+/// ```
 #[derive(Debug)]
 pub struct OrFilter {
     pub(crate) filter1: Box<dyn Filtered>,
     pub(crate) filter2: Box<dyn Filtered>,
 }
 
+/// Represents 'AND'  filter condition for query WHERE clauses.
+///
+/// This struct combines two filter conditions to create
+/// a condition that can be used in database queries.
+///
+/// # Fields
+///
+/// - `filter1`: The first filter condition
+/// - `filter2`: The second filter condition
+///
+/// # Example
+///
+/// ```rust
+/// use lume::filter::AndFilter;
+/// use lume::filter::Filter;
+/// use lume::schema::Value;
+///
+/// let filter = AndFilter {
+///     filter1: Box::new(Filter {
+///         column_one: ("users".to_string(), "age".to_string()),
+///         filter_type: FilterType::Gt,
+///         value: Some(Value::Int8(18)),
+///         column_two: None,
+///     }),
+///     filter2: Box::new(Filter {
+///         column_one: ("users".to_string(), "age".to_string()),
+///         filter_type: FilterType::Lt,
+///         value: Some(Value::Int8(30)),
+///         column_two: None,
+///     }),
+/// };
+/// ```
 #[derive(Debug)]
 pub struct AndFilter {
     pub(crate) filter1: Box<dyn Filtered>,
     pub(crate) filter2: Box<dyn Filtered>,
 }
 
-/// Trait for filter types that can be used in query WHERE clauses.
+/// Trait for all filter types used in query building.
 ///
-/// This trait provides a unified interface for both simple filters ([`Filter`])
-/// and composite OR filters ([`OrFilter`]). It enables dynamic dispatch of
-/// filter operations during query building.
+/// This trait abstracts over different filter types (such as simple column-value filters,
+/// column-column filters, and logical combinators like AND/OR) to allow uniform handling
+/// of filters in query construction and evaluation.
 ///
-/// # Contract
-///
-/// Implementors must ensure:
-/// - When `is_or_filter()` returns `true`, both `filter1()` and `filter2()` must return `Some`
-/// - When `is_or_filter()` returns `false`, both `filter1()` and `filter2()` must return `None`
-/// - At least one of `value()` or `column_two()` should return `Some` for simple comparisons
+/// Implementors of this trait provide access to filter details such as the value being compared,
+/// the columns involved, the filter type (e.g., equality, less-than), and whether the filter
+/// is a logical combinator (AND/OR).
 pub trait Filtered: Debug {
+    /// Returns a reference to the value being compared in the filter, if any.
+    ///
+    /// For simple column-value filters, this returns `Some(&Value)`.
+    /// For logical combinators (AND/OR), this returns `None`.
     fn value(&self) -> Option<&Value>;
+
+    /// Returns a reference to the first column involved in the filter, if any.
+    ///
+    /// For simple filters, this is the column being filtered.
+    /// For logical combinators (AND/OR), this returns `None`.
     fn column_one(&self) -> Option<&(String, String)>;
+
+    /// Returns a reference to the second column involved in the filter, if any.
+    ///
+    /// This is used for column-to-column comparisons (e.g., joins).
+    /// For most filters, this is `None`.
     fn column_two(&self) -> Option<&(String, String)>;
+
+    /// Returns the type of filter (e.g., Eq, Lt, Gt, etc.).
     fn filter_type(&self) -> FilterType;
+
+    /// Returns `true` if this filter is a logical OR combinator.
     fn is_or_filter(&self) -> bool;
+
+    /// Returns `true` if this filter is a logical AND combinator.
     fn is_and_filter(&self) -> bool;
 
+    /// Returns a reference to the first sub-filter if this is a logical combinator.
+    ///
+    /// For AND/OR filters, this returns `Some(&dyn Filtered)`.
+    /// For simple filters, this returns `None`.
     fn filter1(&self) -> Option<&dyn Filtered>;
-    fn filter2(&self) -> Option<&dyn Filtered>;
 
-    fn has_more_filters(&self) -> bool;
+    /// Returns a reference to the second sub-filter if this is a logical combinator.
+    ///
+    /// For AND/OR filters, this returns `Some(&dyn Filtered)`.
+    /// For simple filters, this returns `None`.
+    fn filter2(&self) -> Option<&dyn Filtered>;
 }
 
 impl Filtered for Filter {
@@ -174,10 +262,6 @@ impl Filtered for Filter {
     }
 
     fn is_and_filter(&self) -> bool {
-        false
-    }
-
-    fn has_more_filters(&self) -> bool {
         false
     }
 }
@@ -219,10 +303,6 @@ impl Filtered for OrFilter {
     fn is_and_filter(&self) -> bool {
         false
     }
-
-    fn has_more_filters(&self) -> bool {
-        true
-    }
 }
 
 impl Filtered for AndFilter {
@@ -261,10 +341,6 @@ impl Filtered for AndFilter {
 
     fn filter_type(&self) -> FilterType {
         FilterType::And
-    }
-
-    fn has_more_filters(&self) -> bool {
-        true
     }
 }
 


### PR DESCRIPTION
- Added `has_more_filters` method to the `Filtered` trait to indicate if additional filters are present.
- Refactored SQL generation logic in the `filter_sql` method to utilize a more streamlined approach for building filter expressions.
- Improved handling of filter conditions to support both AND and OR operations more effectively.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added composite OR/AND filters and public helpers to build and inspect nested filters.

* **Bug Fixes**
  * Properly handles NULL comparisons and malformed filters (falls back to neutral conditions).
  * Only adds a WHERE clause when filters exist; parameters are safely bound.

* **Refactor**
  * Reworked filter expression construction into a recursive builder with unified inspection.

* **Documentation**
  * Expanded docs and examples for simple and composite filter usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->