### PR TITLE
Update version to 0.6.0 and enhance API for selecting users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,11 @@
 
 ## [0.6.0] - 2025-10-01
 
-New api like Users::selected().something
-New api like Users::selected().all()
-insert and insert_many returns Result<Option<Vec<Row<T>>>, DatabaseError> now
-Added delete function
-Added in array and not in array filters
-renamed ne to ne_value and added ne_column filter
+- Api for selecting made easier `Users::selected().id()` and `Users::selected().all()`
+- Insert and Insert_many returns Result<Option<Vec<Row<T>>>, DatabaseError> now
+- Added delete function
+- Added in array and not in array filters
+- Renamed ne to ne_value and added ne_column filter
 
 ## [0.5.0] - 2025-09-30
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -632,7 +632,7 @@ checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "lume"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "paste",
  "sqlx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lume"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 license = "MIT"
 authors = ["You guru911u@gmail.com"]

--- a/Readme.md
+++ b/Readme.md
@@ -66,11 +66,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Type-safe queries
     let users = db
         .query::<Users, QueryUsers>()
-        .select(QueryUsers {
-            username: true,
-            age: true,
-            ..Default::default()
-        })
+        .select(QueryUsers::selected().age().username())
         .filter(eq_value(Users::username(), "john_doe"))
         .execute()
         .await?;
@@ -192,7 +188,7 @@ use lume::filter::eq_column;
 // Here we assume a schema with `Author` and `Book` where `Book.author_id` references `Author.id`
 let authors_with_books = db
     .query::<Author, QueryAuthor>()
-    .select(QueryAuthor { name: true, ..Default::default() })
+    .select(QueryAuthor::selected().name())
     .left_join::<Book, QueryBook>(
         eq_column(Author::id(), Book::author_id()),
         QueryBook { title: true, ..Default::default() },


### PR DESCRIPTION
- Bump version in `Cargo.toml` and `Cargo.lock` to 0.6.0.
- Simplify user selection API with `Users::selected().id()` and `Users::selected().all()`.
- Update CHANGELOG to reflect new features and improvements in the API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a fluent selection builder via selected(), enabling chained column selectors (e.g., .age().username(), .name()) for constructing queries more ergonomically.
- Documentation
  - Updated examples to use the new builder-style selection API, replacing prior struct-literal field selection.
  - Clarified selection and insert examples with more concrete usage details.
- Chores
  - Bumped package version to 0.6.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->